### PR TITLE
One instance of db connection

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -9,10 +9,10 @@
 var indexedDB = window.indexedDB||window.mozIndexedDB||window.webkitIndexedDB||window.msIndexedDB;
 var IDBKeyRange=window.IDBKeyRange||window.mozIDBKeyRange||window.webkitIDBKeyRange||window.msIDBKeyRange;
 
-angular.module('xc.indexedDB', []).provider('$indexedDB', function() {    
+angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
     var module          = this,
         /** IDBTransaction mode constants */
-        READONLY        = "readonly", 
+        READONLY        = "readonly",
         READWRITE       = "readwrite",
         VERSIONCHANGE   = "versionchange",
         /** IDBCursor direction and skip behaviour constants */
@@ -20,12 +20,12 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
         NEXTUNIQUE      = "nextunique",
         PREV            = "prev",
         PREVUNIQUE      = "prevunique";
-    
+
     /** predefined variables */
     module.dbName = '';
     module.dbVersion = 1;
     module.db = null;
-    
+
     /** predefined callback functions, can be customized in angular.config */
     module.onTransactionComplete = function(e) {
         console.log('Transaction completed.');
@@ -38,13 +38,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
     };
     module.onDatabaseError = function(e) {
         alert("Database error: " + e.target.webkitErrorMessage || e.target.errorCode);
-    };   
+    };
     module.onDatabaseBlocked = function(e) {
         // If some other tab is loaded with the database, then it needs to be closed
         // before we can proceed.
         alert("Database is blocked. Try close other tabs with this page open and reload this page!");
-    }; 
-    
+    };
+
     /**
      * @ngdoc function
      * @name $indexedDBProvider.connection
@@ -60,13 +60,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
         module.dbName = databaseName;
         return this;
     };
-    
+
     /**
      * @ngdoc function
      * @name $indexedDBProvider.upgradeDatabase
      * @function
      *
-     * @description provides version number and steps to upgrade the database wrapped in a 
+     * @description provides version number and steps to upgrade the database wrapped in a
      * callback function
      *
      * @param {number} newVersion new version number for the database.
@@ -77,14 +77,14 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
         module.dbVersion = newVersion;
         module.upgradeCallback = callback;
         return this;
-    };  
-    
+    };
+
     module.$get = ['$q', '$rootScope', function($q, $rootScope) {
-        /** 
+        /**
          * @ngdoc object
          * @name defaultQueryOptions
          * @function
-         * 
+         *
          * @description optionally specify for cursor requests:
          * - which index to use
          * - a keyRange to apply
@@ -95,12 +95,12 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
             keyRange: null,
             direction: NEXT
         };
-        /** 
+        /**
          * @ngdoc object
-         * @name dbPromise 
+         * @name dbPromise
          * @function
-         * 
-         * @description open the database specified in $indexedDBProvider.connection and 
+         *
+         * @description open the database specified in $indexedDBProvider.connection and
          * $indexdDBProvider.upgradeDatabase and returns a promise for this connection
          * @params
          * @returns {object} promise $q.promise to fullfill connection
@@ -119,7 +119,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 dbReq.onerror = module.onDatabaseError;
                 dbReq.onupgradeneeded = function(e) {
                     var db = e.target.result, tx = e.target.transaction;
-                    console.log('upgrading database "' + db.name + '" from version ' + e.oldVersion+ 
+                    console.log('upgrading database "' + db.name + '" from version ' + e.oldVersion+
                         ' to version ' + e.newVersion + '...');
                     module.upgradeCallback && module.upgradeCallback(e, db, tx);
                 };
@@ -128,32 +128,32 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
             }
             return defered.promise;
         };
-        /** 
+        /**
          * @ngdoc object
-         * @name ObjectStore 
+         * @name ObjectStore
          * @function
-         * 
+         *
          * @description wrapper for IDBObjectStore
-         * 
-         * @params {string} storeName name of the objectstore 
-         */        
+         *
+         * @params {string} storeName name of the objectstore
+         */
         var ObjectStore = function(storeName) {
             this.storeName = storeName;
             this.transaction = undefined;
         };
         ObjectStore.prototype = {
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.internalObjectStore 
+             * @name ObjectStore.internalObjectStore
              * @function
-             * 
+             *
              * @description used internally to retrieve an objectstore
              * with the correct transaction mode
-             * 
+             *
              * @params {string} storeName name of the objectstore
              * @params {string} mode transaction mode to use for operation
              * @returns {object} IDBObjectStore the objectstore in question
-             */  
+             */
             internalObjectStore: function(storeName, mode) {
                 var me = this;
                 return dbPromise().then(function(db){
@@ -165,30 +165,30 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     return me.transaction.objectStore(storeName);
                 });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.abort 
+             * @name ObjectStore.abort
              * @function
-             * 
+             *
              * @description abort the current transaction
-             */  
+             */
             "abort": function() {
                 if (this.transaction) {
                     this.transaction.abort();
                 }
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.insert 
+             * @name ObjectStore.insert
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.add.
              * input data can be a single object or an array of objects for
              * bulk insertions within a single transaction
-             * 
+             *
              * @params {object or array} data the data to insert
              * @returns {object} $q.promise a promise on successfull execution
-             */  
+             */
             "insert": function(data){
                 var d = $q.defer();
                 return this.internalObjectStore(this.storeName, READWRITE).then(function(store){
@@ -196,33 +196,33 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     if (angular.isArray(data)) {
                         data.forEach(function(item){
                             req = store.add(item);
-                            req.onsuccess = req.onerror = function(e) { 
+                            req.onsuccess = req.onerror = function(e) {
                                 $rootScope.$apply(function(){
-                                    d.resolve(e.target.result); 
+                                    d.resolve(e.target.result);
                                 });
                             };
                         });
                     } else {
                         req = store.add(data);
-                        req.onsuccess = req.onerror = function(e) { 
+                        req.onsuccess = req.onerror = function(e) {
                             $rootScope.$apply(function(){
-                                d.resolve(e.target.result); 
+                                d.resolve(e.target.result);
                             });
                         };
                     }
                     return d.promise;
-                });                      
+                });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.upsert 
+             * @name ObjectStore.upsert
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.put.
              * modifies existing values or inserts as new value if nonexistant
              * input data can be a single object or an array of objects for
              * bulk updates/insertions within a single transaction
-             * 
+             *
              * @params {object or array} data the data to upsert
              * @returns {object} $q.promise a promise on successfull execution
              */
@@ -233,31 +233,31 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     if (angular.isArray(data)) {
                         data.forEach(function(item){
                             req = store.put(item);
-                            req.onsuccess = req.onerror = function(e) { 
+                            req.onsuccess = req.onerror = function(e) {
                                 $rootScope.$apply(function(){
-                                    d.resolve(e.target.result); 
+                                    d.resolve(e.target.result);
                                 });
                             };
                         });
                     } else {
                         req = store.put(data);
-                        req.onsuccess = req.onerror = function(e) { 
+                        req.onsuccess = req.onerror = function(e) {
                             $rootScope.$apply(function(){
-                                d.resolve(e.target.result); 
+                                d.resolve(e.target.result);
                             });
                         };
                     }
                     return d.promise;
-                });                      
+                });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.delete 
+             * @name ObjectStore.delete
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.delete.
              * deletes the value for the specified primary key
-             * 
+             *
              * @params {any value} key primary key to indetify a value
              * @returns {object} $q.promise a promise on successfull execution
              */
@@ -265,44 +265,44 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 var d = $q.defer();
                 return this.internalObjectStore(this.storeName, READWRITE).then(function(store){
                     var req = store.delete(key);
-                    req.onsuccess = req.onerror = function(e) { 
+                    req.onsuccess = req.onerror = function(e) {
                         $rootScope.$apply(function(){
-                            d.resolve(e.target.result); 
+                            d.resolve(e.target.result);
                         });
                     };
                     return d.promise;
                 });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.clear 
+             * @name ObjectStore.clear
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.clear.
              * removes all data in an objectstore
-             * 
+             *
              * @returns {object} $q.promise a promise on successfull execution
              */
             "clear": function() {
                 var d = $q.defer();
                 return this.internalObjectStore(this.storeName, READWRITE).then(function(store){
                     var req = store.clear();
-                    req.onsuccess = req.onerror = function(e) { 
+                    req.onsuccess = req.onerror = function(e) {
                         $rootScope.$apply(function(){
-                            d.resolve(e.target.result); 
+                            d.resolve(e.target.result);
                         });
                     };
                     return d.promise;
-                });                
+                });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.count 
+             * @name ObjectStore.count
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.count.
              * returns the number of values in the objectstore, as a promise
-             * 
+             *
              * @returns {object} $q.promise a promise on successfull execution
              */
             "count": function() {
@@ -310,14 +310,14 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     return store.count();
                 });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.find 
+             * @name ObjectStore.find
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.get and IDBIndex.get.
              * retrieves a single value with specified key, or index-key
-             * 
+             *
              * @params {any value} keyOrIndex the key to value, or an indexName
              * @params {any value} key the key of an index (*optional*)
              * @returns {any value} value ...wrapped in a promise
@@ -326,41 +326,41 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 var d = $q.defer();
                 var promise = d.promise;
                 return this.internalObjectStore(this.storeName, READONLY).then(function(store){
-                    var req;                   
-                    
+                    var req;
+
                     if(keyIfIndex) {
                         req = store.index(keyOrIndex).get(keyIfIndex);
                     } else {
                         req = store.get(keyOrIndex);
                     }
-                    req.onsuccess = req.onerror = function(e) { 
+                    req.onsuccess = req.onerror = function(e) {
                         $rootScope.$apply(function(){
-                            d.resolve(e.target.result); 
+                            d.resolve(e.target.result);
                         });
                     };
                     return promise;
                 });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.getAll 
+             * @name ObjectStore.getAll
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.getAll (or shim).
              * retrieves all values from objectstore using IDBObjectStore.getAll
              * or a cursor request if getAll is not implemented
-             * 
+             *
              * @returns {array} values ...wrapped in a promise
              */
             "getAll": function() {
                 var results = [], d = $q.defer();
                 return this.internalObjectStore(this.storeName, READONLY).then(function(store){
                     var req;
-                    if (store.getAll) {         
+                    if (store.getAll) {
                         req = store.getAll();
-                        req.onsuccess = req.onerror = function(e) { 
+                        req.onsuccess = req.onerror = function(e) {
                             $rootScope.$apply(function(){
-                                d.resolve(e.target.result); 
+                                d.resolve(e.target.result);
                             });
                         };
                     } else {
@@ -383,16 +383,16 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     return d.promise;
                 });
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name ObjectStore.each 
+             * @name ObjectStore.each
              * @function
-             * 
+             *
              * @description wrapper for IDBObjectStore.openCursor or IDBIndex.openCursor.
-             * returns an IDBCursor for further manipulation. See indexedDB documentation 
+             * returns an IDBCursor for further manipulation. See indexedDB documentation
              * for details on this.
              * https://developer.mozilla.org/en-US/docs/IndexedDB/Using_IndexedDB#Using_a_cursor
-             * 
+             *
              * @params {object} options optional query parameters, see defaultQueryOptions
              * and QueryBuilder for details
              * @returns {object} IDBCursor ...wrapped in a promise
@@ -407,34 +407,34 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     } else {
                         req = store.openCursor(options.keyRange, options.direction);
                     }
-                    req.onsuccess = req.onerror = function(e) { 
+                    req.onsuccess = req.onerror = function(e) {
                         $rootScope.$apply(function(){
-                            d.resolve(e.target.result); 
+                            d.resolve(e.target.result);
                         });
                     };
                     return d.promise;
                 });
             }
         };
-        
-        /** 
+
+        /**
          * @ngdoc object
-         * @name QueryBuilder 
+         * @name QueryBuilder
          * @function
-         * 
+         *
          * @description utility object to easily create IDBKeyRange for cursor queries
          */
         var QueryBuilder = function() {
             this.result = defaultQueryOptions;
         };
         QueryBuilder.prototype = {
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$lt 
+             * @name QueryBuilder.$lt
              * @function
-             * 
+             *
              * @description set an upper bound, e.g. A < value, excluding value
-             * 
+             *
              * @params {any value} value bound value
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -442,13 +442,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.upperBound(value, true);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$gt 
+             * @name QueryBuilder.$gt
              * @function
-             * 
+             *
              * @description set a lower bound, e.g. A > value, excluding value
-             * 
+             *
              * @params {any value} value bound value
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -456,13 +456,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.lowerBound(value, true);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$lte 
+             * @name QueryBuilder.$lte
              * @function
-             * 
+             *
              * @description set an upper bound, e.g. A <= value, including value
-             * 
+             *
              * @params {any value} value bound value
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -470,13 +470,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.upperBound(value);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$gte 
+             * @name QueryBuilder.$gte
              * @function
-             * 
+             *
              * @description set an upper bound, e.g. A >= value, including value
-             * 
+             *
              * @params {any value} value bound value
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -484,13 +484,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.lowerBound(value);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$eq 
+             * @name QueryBuilder.$eq
              * @function
-             * 
+             *
              * @description exact match, e.g. A = value
-             * 
+             *
              * @params {any value} value bound value
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -498,14 +498,14 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.only(value);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
-             * @name QueryBuilder.$between 
+             * @name QueryBuilder.$between
              * @function
-             * 
+             *
              * @description set an upper and lower bound, e.g. low >= value <= hi,
              * optionally including value
-             * 
+             *
              * @params {any value} lowValue lower bound value
              * @params {any value} hiValue upper bound value
              * @params {boolean} exLow optional, exclude lower bound value
@@ -516,14 +516,14 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.keyRange = IDBKeyRange.bound(lowValue,hiValue,exLow||false,exHi||false);
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name QueryBuilder.$asc
              * @function
-             * 
+             *
              * @description set the direction of traversal to ascending (natural)
-             * 
-             * @params {boolean} unique return only distinct values, skipping 
+             *
+             * @params {boolean} unique return only distinct values, skipping
              * duplicates (*optional*)
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -531,14 +531,14 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.order = (unique)? NEXTUNIQUE: NEXT;
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name QueryBuilder.$desc
              * @function
-             * 
+             *
              * @description set the direction of traversal to descending order
-             * 
-             * @params {boolean} unique return only distinct values, skipping 
+             *
+             * @params {boolean} unique return only distinct values, skipping
              * duplicates (*optional*)
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -546,13 +546,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.order = (unique)? PREVUNIQUE: PREV;
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name QueryBuilder.$index
              * @function
-             * 
+             *
              * @description optionally specify an index to use
-             * 
+             *
              * @params {string} indexName index to use
              * @returns {object} this QueryBuilder, for chaining params
              */
@@ -560,50 +560,50 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 this.result.useIndex = indexName;
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name QueryBuilder.compile
              * @function
-             * 
+             *
              * @description returns an object to be passed to ObjectStore.each
-             * @returns {object} queryOptions 
+             * @returns {object} queryOptions
              */
             "compile": function() {
                 return this.result;
             }
         };
-                
-        /** 
+
+        /**
          * @ngdoc angular.$provider
          * @name $indexedDB
          * @function
-         * 
+         *
          * @description indexedDB provider object
          */
         return {
-            /** 
+            /**
              * @ngdoc method
              * @name $indexedDB.objectStore
              * @function
-             * 
+             *
              * @description an IDBObjectStore to use
-             * 
+             *
              * @params {string} storename the name of the objectstore to use
              * @returns {object} ObjectStore
              */
             "objectStore": function(storeName) {
                 return new ObjectStore(storeName);
             },
-            /** 
+            /**
              * @ngdoc method
              * @name $indexedDB.dbInfo
              * @function
-             * 
+             *
              * @description statistical information about the current database
              * - database name and version
-             * - objectstores in in database with name, value count, keyPath, 
+             * - objectstores in in database with name, value count, keyPath,
              *   autoincrement flag and current assigned indices
-             * 
+             *
              * @returns {object} DBInfo
              */
             "dbInfo": function() {
@@ -628,11 +628,11 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                     };
                 });
             },
-            /** 
+            /**
              * @ngdoc method
              * @name $indexedDB.close
              * @function
-             * 
+             *
              * @description closes the current active database
              * @returns {object} this
              */
@@ -642,15 +642,15 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 });
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name $indexedDB.switchDB
              * @function
-             * 
+             *
              * @description closes the current active database and opens another one
-             * 
+             *
              * @params {string} databaseName the name of the database to use
-             * @params {number} version the version number of the database 
+             * @params {number} version the version number of the database
              * @params {Function} upgradeCallBack the callback which proceeds the upgrade
              * @returns {object} this
              */
@@ -662,13 +662,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 module.upgradeCallback = upgradeCallback || function() {};
                 return this;
             },
-            /** 
+            /**
              * @ngdoc method
              * @name $indexedDB.queryBuilder
              * @function
-             * 
+             *
              * @description provides access to the QueryBuilder utility
-             * 
+             *
              * @returns {object} QueryBuilder
              */
             "queryBuilder": function() {


### PR DESCRIPTION
Current version has possibility to open two database connections -- if one call dbPromise() simultaneously one after another. I fixed it by storing the promise of db opening request. 
