### PR TITLE
Fixed undefined error messages

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -32,13 +32,13 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
         console.log('Transaction completed.');
     };
     module.onTransactionAbort = function(e) {
-        console.log('Transaction aborted: '+ e.target.webkitErrorMessage || e.target.errorCode);
+        console.log('Transaction aborted: '+ (e.target.webkitErrorMessage || e.target.error.message || e.target.errorCode));
     };
     module.onTransactionError = function(e) {
         console.log('Transaction failed: ' + e.target.errorCode);
     };
     module.onDatabaseError = function(e) {
-        alert("Database error: " + e.target.webkitErrorMessage || e.target.errorCode);
+        alert("Database error: " + (e.target.webkitErrorMessage || e.target.errorCode));
     };
     module.onDatabaseBlocked = function(e) {
         // If some other tab is loaded with the database, then it needs to be closed


### PR DESCRIPTION
In Firefox on the transaction abort event, the "e.target.errorCode" is not defined but the e.target.error object contains a "message" and a "name" key. Here i used the "message" one.
Parenthesis were missing, too.
