### PR TITLE
Fixed insert and upsert never resolving

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -211,7 +211,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                                 });
                             };
                             req.onsuccess = function(e) {
-                                if(i == data.length) {
+                                if(i == data.length - 1) {
                                     $rootScope.$apply(function(){
                                         d.resolve(e.target.result);
                                     });
@@ -260,7 +260,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                                 });
                             };
                             req.onsuccess = function(e) {
-                                if(i == data.length) {
+                                if(i == data.length - 1) {
                                     $rootScope.$apply(function(){
                                         d.resolve(e.target.result);
                                     });


### PR DESCRIPTION
Both ObjectStore.insert and ObjectStore.upsert never resolve their
promise because of an index comparison that is never true. Changing the
comparison to be between the index and the length of the data - 1
resolves the problem.
