### PR TITLE
Fixed bug in  README inside Usage section: missing parantheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ angular.module('myModuleName')
    * find all persons older than 40 years
    */
    
-   var myQuery = $indexedDB.queryBuilder.$index('age_idx').$gt(40).$asc.compile;
+   var myQuery = $indexedDB.queryBuilder().$index('age_idx').$gt(40).$asc.compile();
    myObjectStore.each(myQuery).then(function(cursor){
      cursor.key;
      cursor.value;


### PR DESCRIPTION
When executing a query, the lack of parantheses in function calls lead users to mustake.
Reported error from another user: https://github.com/webcss/angular-indexedDB/issues/9
