### PR TITLE
Fix Database error: undefined and count returns IDBRequest instead of result

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -204,7 +204,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                                $rootScope.$apply(function(){
                                     d.notify(e.target.result);
                                 }); 
-                            }
+                            };
                             req.onerror = function(e) {
                                 $rootScope.$apply(function(){
                                     d.reject(e.target.result);
@@ -253,7 +253,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                                $rootScope.$apply(function(){
                                     d.notify(e.target.result);
                                 }); 
-                            }
+                            };
                             req.onerror = function(e) {
                                 $rootScope.$apply(function(){
                                     d.reject(e.target.result);
@@ -334,8 +334,15 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
              * @returns {object} $q.promise a promise on successfull execution
              */
             "count": function() {
+                var d = $q.defer();
                 return this.internalObjectStore(this.storeName, READONLY).then(function(store){
-                    return store.count();
+                    var req = store.count();
+                    req.onsuccess = req.onerror = function(e) {
+                        $rootScope.$apply(function(){
+                            d.resolve(e.target.result);
+                        });
+                    };
+                    return d.promise;
                 });
             },
             /**


### PR DESCRIPTION
In Google Chrome e.target.errorCode is undefined. Adding e.target.error.message fixes the Database error: undefined I received when upgrading the database and the transaction was aborted. The same change was made to the onTransactionError function assuming the same applies.
