### PR TITLE
Fix problem with Firefox

### DIFF
--- a/src/indexeddb.js
+++ b/src/indexeddb.js
@@ -117,7 +117,7 @@ angular.module('xc.indexedDB', []).provider('$indexedDB', function() {
                 deferred = $q.defer();
                 module.dbPromise = deferred.promise;
 
-                dbReq = indexedDB.open(module.dbName, module.dbVersion || 1);
+                dbReq = $window.indexedDB.open(module.dbName, module.dbVersion || 1);
                 dbReq.onsuccess = function(e) {
                     module.db = dbReq.result;
                     $rootScope.$apply(function(){


### PR DESCRIPTION
Hi,

   In Firefox 31 (latest version), I can't use the library because it already has the indexedDB var in the window scope. As we are using strict mode, we receive the following error:

TypeError: setting a property that has only a getter

This pull request is to fix this exact problem by replacing line 9 by this:

if(!('indexedDB' in window)) {
    var indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
}
